### PR TITLE
feat: Add HackerTables with relational database updates

### DIFF
--- a/prisma/migrations/20240329163836_team_hacker_table_relation/migration.sql
+++ b/prisma/migrations/20240329163836_team_hacker_table_relation/migration.sql
@@ -1,0 +1,33 @@
+-- CreateTable
+CREATE TABLE "TableRow" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT
+);
+
+-- CreateTable
+CREATE TABLE "HackerTable" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "Name" TEXT NOT NULL,
+    "Space" TEXT NOT NULL,
+    "rowId" INTEGER NOT NULL,
+    CONSTRAINT "HackerTable_rowId_fkey" FOREIGN KEY ("rowId") REFERENCES "TableRow" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Team" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "ownerId" INTEGER NOT NULL,
+    "hackerTableId" INTEGER,
+    CONSTRAINT "Team_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "Hacker" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Team_hackerTableId_fkey" FOREIGN KEY ("hackerTableId") REFERENCES "HackerTable" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Team" ("code", "id", "name", "ownerId") SELECT "code", "id", "name", "ownerId" FROM "Team";
+DROP TABLE "Team";
+ALTER TABLE "new_Team" RENAME TO "Team";
+CREATE UNIQUE INDEX "Team_name_key" ON "Team"("name");
+CREATE UNIQUE INDEX "Team_code_key" ON "Team"("code");
+CREATE UNIQUE INDEX "Team_ownerId_key" ON "Team"("ownerId");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/prisma/migrations/20240330184240_table_row_add_hackathon_id/migration.sql
+++ b/prisma/migrations/20240330184240_table_row_add_hackathon_id/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - Added the required column `hackathonId` to the `TableRow` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_TableRow" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "hackathonId" INTEGER NOT NULL,
+    CONSTRAINT "TableRow_hackathonId_fkey" FOREIGN KEY ("hackathonId") REFERENCES "Hackathon" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_TableRow" ("id") SELECT "id" FROM "TableRow";
+DROP TABLE "TableRow";
+ALTER TABLE "new_TableRow" RENAME TO "TableRow";
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,6 +61,7 @@ model Hackathon {
   sponsors                       Sponsor[]
   applicationFormSteps           ApplicationFormStep[]
   voteParameters                 VoteParameter[]
+  tableRows                      TableRow[]
   createdAt                      DateTime              @default(now())
   updatedAt                      DateTime              @updatedAt
 }
@@ -81,12 +82,14 @@ model Hacker {
 }
 
 model Team {
-  id      Int      @id @default(autoincrement())
-  name    String   @unique
-  code    String   @unique
-  ownerId Int      @unique
-  owner   Hacker   @relation(name: "TeamOwner", fields: [ownerId], references: [id])
-  members Hacker[]
+  id            Int          @id @default(autoincrement())
+  name          String       @unique
+  code          String       @unique
+  ownerId       Int          @unique
+  owner         Hacker       @relation(name: "TeamOwner", fields: [ownerId], references: [id])
+  members       Hacker[]
+  hackerTableId Int?
+  hackerTable   HackerTable? @relation(fields: [hackerTableId], references: [id])
 }
 
 model Organizer {
@@ -286,4 +289,20 @@ model TravelReimbursementRequestStatus {
   requests  TravelReimbursementRequest[]
   createdAt DateTime                     @default(now())
   updatedAt DateTime                     @updatedAt
+}
+
+model TableRow {
+  id           Int           @id @default(autoincrement())
+  hackathonId  Int
+  hackathon    Hackathon     @relation(fields: [hackathonId], references: [id])
+  HackerTables HackerTable[] // updated Table to HackerTable
+}
+
+model HackerTable {
+  id       Int      @id @default(autoincrement())
+  Name     String
+  Space    String
+  rowId    Int
+  TableRow TableRow @relation(fields: [rowId], references: [id])
+  Team     Team[]
 }

--- a/src/app/dashboard/[hackathonId]/hacker-tables/page.tsx
+++ b/src/app/dashboard/[hackathonId]/hacker-tables/page.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import getAllTableRows from "@/server/getters/dashboard/hackerTablesManager/getAllTableRows";
+import { TableRow, HackerTable } from "@prisma/client";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import addNewTableRow from "@/server/actions/dashboard/hackerTableManager/addNewTableRow";
+import AddNewTableRowButton from "@/scenes/Dashboard/components/AddTableRow";
+import { PencilSquareIcon } from "@heroicons/react/24/solid";
+import { DeleteIcon } from "lucide-react";
+
+export const metadata = {
+  title: "Hacker Tables",
+};
+
+const HackerTablesPage = async (props: { params: { hackathonId: string } }) => {
+  const {
+    params: { hackathonId },
+  } = props;
+
+  const tableRows: TableRow[] = await getAllTableRows(Number(hackathonId));
+
+  return (
+    <div>
+      <h1>Hacker Tables</h1>
+      <AddNewTableRowButton hackathonId={Number(hackathonId)} />
+      {tableRows.map((row: TableRow) => (
+        <div key={row.id} className="pt-5">
+          <div className="flex items-center space-x-4">
+            <h3>Row: </h3>
+            <Button variant="outline">
+              <DeleteIcon className="w-4 h-4 mr-1 text-hkOrange inline" />
+              Remove Row
+            </Button>
+          </div>
+          <Card className="flex">
+            {row.HackerTables.map((table: HackerTable) => (
+              <div
+                key={table.id}
+                className={`flex-1 bg-gray rounded shadow mr-${table.Space} px-2 py-3`}
+              >
+                <h3>{table.Name}</h3>
+                {table.Team.map(
+                  (
+                    team: any // Loop through the Team array
+                  ) => (
+                    <h4 key={team.id}>{team.members.length}</h4> // Display team name, assuming team object structure has a field called `name`
+                  )
+                )}
+              </div>
+            ))}
+          </Card>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default HackerTablesPage;

--- a/src/scenes/Dashboard/components/AddTableRow.tsx
+++ b/src/scenes/Dashboard/components/AddTableRow.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import React from "react";
+import { Button } from "@/components/ui/button";
+import useLog, { LogAction } from "@/services/hooks/useLog";
+import addNewTableRow from "@/server/actions/dashboard/hackerTableManager/addNewTableRow";
+
+interface AddNewTableRowButtonProps {
+  hackathonId: number;
+}
+
+const AddNewTableRowButton: React.FC<AddNewTableRowButtonProps> = ({
+  hackathonId,
+}) => {
+  const { log } = useLog();
+
+  const onAddNewTableRowClick = async () => {
+    log({
+      action: LogAction.ButtonClicked,
+      detail: "Add Table Row",
+    });
+    try {
+      await addNewTableRow(Number(hackathonId));
+    } catch (error) {
+      console.error("Failed to add new table row:", error);
+    }
+  };
+
+  return (
+    <Button size="small" onClick={onAddNewTableRowClick}>
+      Add new Row
+    </Button>
+  );
+};
+
+export default AddNewTableRowButton;

--- a/src/scenes/Dashboard/scenes/HackathonDashboardLayout/components/DashboardTabs.tsx
+++ b/src/scenes/Dashboard/scenes/HackathonDashboardLayout/components/DashboardTabs.tsx
@@ -49,6 +49,9 @@ const DashboardTabs = ({ hackathonId, isAdmin }: DashboardTabsProps) => {
       case "settings":
         push(`/dashboard/${hackathonId}/settings`);
         break;
+      case "tables":
+        push(`/dashboard/${hackathonId}/hacker-tables`);
+        break;
     }
   };
 
@@ -74,6 +77,7 @@ const DashboardTabs = ({ hackathonId, isAdmin }: DashboardTabsProps) => {
         <TabsTrigger value="checkin">Check-in</TabsTrigger>
         {isAdmin && <TabsTrigger value="form">Application form</TabsTrigger>}
         {isAdmin && <TabsTrigger value="info">Hackathon info</TabsTrigger>}
+        {isAdmin && <TabsTrigger value="tables">Tables</TabsTrigger>}
         {isAdmin && <TabsTrigger value="settings">Settings</TabsTrigger>}
       </TabsList>
     </Tabs>

--- a/src/server/actions/dashboard/hackerTableManager/addNewTableRow.ts
+++ b/src/server/actions/dashboard/hackerTableManager/addNewTableRow.ts
@@ -1,0 +1,13 @@
+"use server";
+
+import { prisma } from "@/services/prisma";
+
+const addNewTableRow = async (hackathonId: number) => {
+  await prisma.tableRow.create({
+    data: {
+      hackathonId: hackathonId,
+    },
+  });
+};
+
+export default addNewTableRow;

--- a/src/server/getters/dashboard/hackerTablesManager/getAllTableRows.ts
+++ b/src/server/getters/dashboard/hackerTablesManager/getAllTableRows.ts
@@ -1,0 +1,23 @@
+import { prisma } from "@/services/prisma";
+
+const getAllTableRows = async (hackathonId: number) => {
+  const allRows = await prisma.tableRow.findMany({
+    where: {
+      hackathonId: hackathonId,
+    },
+    include: {
+      HackerTables: {
+        include: {
+          Team: {
+            include: {
+              members: true,
+            },
+          },
+        },
+      },
+    },
+  });
+  return allRows;
+};
+
+export default getAllTableRows;


### PR DESCRIPTION
This commit introduces new database tables, TableRow and HackerTable, and modifies the Team table to include hackerTableId. It also adds a new route at /dashboard/{hackathonId}/hacker-tables, implementing the ability to manage 'Hacker Tables' in the hackathon dashboard. Helper functions for adding new rows and fetching all table rows are also included.