### PR TITLE
Add total approved amount to travel reimbursement table

### DIFF
--- a/src/scenes/Dashboard/scenes/TravelReimbursements/components/TravelReimbursementRequestTable.tsx
+++ b/src/scenes/Dashboard/scenes/TravelReimbursements/components/TravelReimbursementRequestTable.tsx
@@ -214,7 +214,28 @@ const TravelReimbursementRequestTable = ({
       ] as ColumnDef<TravelReimbursementRequest>[],
     [params, actionType]
   );
-  return <DataTable columns={columns} data={requests} />;
+
+  const totalAmount = useMemo(
+    () =>
+      requests.reduce(
+        (accum, request) => accum + (request.approvedAmount ?? 0),
+        0
+      ),
+    [requests]
+  );
+
+  return (
+    <>
+      <p>
+        Total Amount:{" "}
+        {new Intl.NumberFormat("sk-SK", {
+          style: "currency",
+          currency: "EUR",
+        }).format(totalAmount)}
+      </p>
+      <DataTable columns={columns} data={requests} />
+    </>
+  );
 };
 
 export default TravelReimbursementRequestTable;


### PR DESCRIPTION
Added a feature that calculates the total approved amount of all travel reimbursement requests. The total is displayed at the top of the reimbursement request table. This change provides a quick overview of the total expenses in the travel reimbursement request table.