### PR TITLE
fix: ensure correct hackathonId for application review

### DIFF
--- a/src/server/getters/dashboard/applicationReview/getApplicationIdForReview.ts
+++ b/src/server/getters/dashboard/applicationReview/getApplicationIdForReview.ts
@@ -51,10 +51,28 @@ const getApplicationIdForReview = async (
   });
 
   if (currentApplicationForReviewId) {
-    return {
-      totalApplicationsLeftToReviewCount: applications.length,
-      applicationId: currentApplicationForReviewId,
-    };
+    // Fetch the current application for review
+    const currentApplicationForReview = await prisma.application.findUnique({
+      where: {
+        id: currentApplicationForReviewId,
+      },
+      select: {
+        hacker: {
+          select: {
+            hackathonId: true,
+          },
+        },
+      },
+    });
+    if (
+      currentApplicationForReview &&
+      currentApplicationForReview.hacker.hackathonId === hackathonId
+    ) {
+      return {
+        totalApplicationsLeftToReviewCount: applications.length,
+        applicationId: currentApplicationForReviewId,
+      };
+    }
   }
 
   if (applications.length === 0) {


### PR DESCRIPTION
Update getApplicationIdForReview to validate hackathonId for reviewing applications. This ensures that only applications from the current hackathon are fetched and processed correctly.