### PR TITLE
feat: allow table assignment for partially confirmed teams and fix fr…

### DIFF
--- a/src/scenes/Dashboard/scenes/TablesManager/TablesManager.tsx
+++ b/src/scenes/Dashboard/scenes/TablesManager/TablesManager.tsx
@@ -74,11 +74,11 @@ const TablesManager = async ({ hackathonId }: TablesManagerProps) => {
               <Heading size="small">
                 Partially confirmed teams ({partiallyConfirmedTeams.length})
               </Heading>
-              <ul>
+              <div className="flex flex-col gap-1">
                 {partiallyConfirmedTeams.map((team) => (
-                  <li key={team.name}>{team.name}</li>
+                  <TeamRow team={team} key={team.id} challenges={challenges} />
                 ))}
-              </ul>
+              </div>
             </div>
           </div>
           <div className="pr-20">

--- a/src/server/getters/application/application.ts
+++ b/src/server/getters/application/application.ts
@@ -192,6 +192,7 @@ const getApplicationData = async ({
   if (!tableCode) {
     const tables = await prisma.table.findMany({
       where: {
+        hackathonId,
         teams: {
           none: {},
         },


### PR DESCRIPTION
…ee tables scope

- Show partially confirmed teams with full TeamRow (assign/unassign table + challenges)
- Filter free tables list by hackathonId so only current event's unassigned tables are shown